### PR TITLE
Make Slurm_Showq::uid_to_string() use a cache

### DIFF
--- a/slurm_showq.cpp
+++ b/slurm_showq.cpp
@@ -883,12 +883,26 @@ std::string Slurm_Showq::uid_to_string(uid_t id)
   std::string username="nobody";
   struct passwd *pwd;
 
-  if( (pwd = getpwuid(id)) == NULL)
-    printf("Error: unable to ascertain user for uid = %u\n",id);
-  else
+  static TUserCache UserUidMap;
+
+  if ( UserUidMap.find(id) == UserUidMap.end() )
+  {
+
+    pwd = getpwuid(id);
+    if (NULL == pwd)
+    {
+      printf("Error: unable to ascertain user for uid = %u\n",id);
+    }
+    else
     {
       username = pwd->pw_name;
+      UserUidMap[id]=username;
     }
+  }
+  else
+  {
+    username = UserUidMap[id];
+  }
 
   return(username);
       

--- a/slurm_showq.h
+++ b/slurm_showq.h
@@ -33,6 +33,10 @@
 
 using namespace std;
 
+// Type for a user cache mapping uid <-> username.
+# include <map>
+typedef std::map<uid_t, std::string> TUserCache;
+
 #include <sys/types.h>
 #include <pwd.h>
 #include <libgen.h>


### PR DESCRIPTION
Currently the Slurm_Showq::uid_to_string() function calls getpwuid()
for every lookup, and loops through all jobs multiple times.

Instead we use a std::map to build a cache that maps user IDs to users.

This resulted in a 73X speedup on the login node of one of our Intel
clusters with over 900 jobs in the queue, going from 22 seconds to
0.3 seconds.
