### PR TITLE
ignore error about undefined users

### DIFF
--- a/slurm_showq.cpp
+++ b/slurm_showq.cpp
@@ -977,11 +977,7 @@ std::string Slurm_Showq::uid_to_string(uid_t id)
   {
 
     pwd = getpwuid(id);
-    if (NULL == pwd)
-    {
-      printf("Error: unable to ascertain user for uid = %u\n",id);
-    }
-    else
+    if (NULL != pwd)
     {
       username = pwd->pw_name;
       UserUidMap[id]=username;


### PR DESCRIPTION
Our cluster is currently split in two sections, one for regular research users, the other for academic students. Each of the two sections is bound to a different user directory.
While the SLURM master resolves users in both directories, compute and login nodes in each of the two sections of the system only see the user directory relevant to it. 
This causes the tool to print errors about not being able to resolve some of the users.
We might want think of a better solution later, but for the time being suppressing the error seems sufficient to our needs.